### PR TITLE
Create separate binary for common wallpapers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,12 +12,20 @@ Rules-Requires-Root: no
 Package: mamolinux-wallpapers
 Architecture: all
 Section: metapackages
-Depends: mamolinux-wallpapers-lunar,
+Depends: mamolinux-wallpapers-common,
+         mamolinux-wallpapers-lunar,
          ubuntu-wallpapers-lunar,
          ${misc:Depends}
 Description: Wallpapers for MamoLinux
  Contains backgrounds for desktop, login-screen
  and grub to be used by MamoLinux
+
+Package: mamolinux-wallpapers-common
+Architecture: all
+Depends: ${misc:Depends}
+Description: Common Wallpapers for MamoLinux
+ Contains common backgrounds for desktop, login-screen
+ and grub to be used by all MamoLinux versions
 
 Package: mamolinux-wallpapers-jammy
 Architecture: all

--- a/debian/mamolinux-wallpapers-common.install
+++ b/debian/mamolinux-wallpapers-common.install
@@ -1,0 +1,3 @@
+usr/share/backgrounds/grub
+usr/share/backgrounds/mamolinux-wallpapers
+usr/share/backgrounds/tiger-wallpaper

--- a/debian/mamolinux-wallpapers-jammy.install
+++ b/debian/mamolinux-wallpapers-jammy.install
@@ -1,4 +1,1 @@
-usr/share/backgrounds/grub
-usr/share/backgrounds/mamolinux-wallpapers
-usr/share/backgrounds/tiger-wallpaper
 usr/share/backgrounds/jellyfish

--- a/debian/mamolinux-wallpapers-lunar.install
+++ b/debian/mamolinux-wallpapers-lunar.install
@@ -1,4 +1,1 @@
-usr/share/backgrounds/grub
-usr/share/backgrounds/mamolinux-wallpapers
-usr/share/backgrounds/tiger-wallpaper
 usr/share/backgrounds/lobster


### PR DESCRIPTION
- Add common wallpapers to mamolinux-wallpapers-common
- Keep release specific wallpapers in mamolinux-wallpapers-jammy and mamolinux-wallpapers-lunar
- Add mamolinux-wallpapers-common as dependency to mamolinux-wallpapers